### PR TITLE
Add support for sampling from MissRow constraints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Clara Hobbs"]
 version = "0.1.0"
 
 [deps]
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,10 @@ uuid = "f1524149-62f5-490d-8249-9bfac76a7111"
 authors = ["Clara Hobbs"]
 version = "0.1.0"
 
+[deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
 [compat]
 julia = "^1.6"
 

--- a/docs/src/weaklyhard.md
+++ b/docs/src/weaklyhard.md
@@ -4,7 +4,7 @@ RealTimeScheduling provides basic support for weakly hard constraints.
 
 !!! warning
     Support for weakly hard systems is still a work in progress, and the API is
-    still very incomplete.  For now, we only support the constraints
+    still very incomplete.  For now, we mainly support the constraints
     themselves, as well as comparisons between them.
 
 ```@docs
@@ -13,4 +13,19 @@ MeetAny
 MissAny
 MeetRow
 MissRow
+```
+
+## Sampling from Weakly Hard Constraints
+
+A weakly hard constraint can be viewed as a sample space of bit strings, with
+`0` representing a deadline miss, and `1` representing a deadline hit.  A
+finite length must be provided to generate such a string.  For now, we only
+support sampling from [`MissRow`](@ref) constraints, which is done uniformly.
+
+Unfortunately, the requirement of specifying a string length precludes the
+easiest use of the `Random.rand` API.  However, the precomputation required is
+non-negligible, so it would be a good idea to first create a sampler anyway.
+
+```@docs
+SamplerMissRow
 ```

--- a/docs/src/weaklyhard.md
+++ b/docs/src/weaklyhard.md
@@ -20,12 +20,12 @@ MissRow
 A weakly hard constraint can be viewed as a sample space of bit strings, with
 `0` representing a deadline miss, and `1` representing a deadline hit.  A
 finite length must be provided to generate such a string.  For now, we only
-support sampling from [`MissRow`](@ref) constraints, which is done uniformly.
+support uniform sampling from [`MissRow`](@ref) constraints.
 
 Unfortunately, the requirement of specifying a string length precludes the
 easiest use of the `Random.rand` API.  However, the precomputation required is
 non-negligible, so it would be a good idea to first create a sampler anyway.
 
 ```@docs
-SamplerMissRow
+SamplerUniformMissRow
 ```

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -24,6 +24,7 @@ export AbstractRealTimeTask,
        MeetRow,
        MissAny,
        MissRow,
+       SamplerMissRow,
        # Schedulability tests
        schedulable_fixed_priority
 include("tasks.jl")

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -24,7 +24,7 @@ export AbstractRealTimeTask,
        MeetRow,
        MissAny,
        MissRow,
-       SamplerMissRow,
+       SamplerUniformMissRow,
        # Schedulability tests
        schedulable_fixed_priority
 include("tasks.jl")

--- a/src/weaklyhard.jl
+++ b/src/weaklyhard.jl
@@ -93,14 +93,14 @@ function <=(c::MeetAny, d::MeetRow)
 end
 
 
-struct SamplerMissRow <: Random.Sampler{BitVector}
+struct SamplerUniformMissRow <: Random.Sampler{BitVector}
     constraint::MissRow
     H::Int64
     l::Matrix{BigInt}
 end
 
 """
-    SamplerMissRow(constraint::MissRow, H::Int64)
+    SamplerUniformMissRow(constraint::MissRow, H::Int64)
 
 Pre-compute data for uniformly sampling `BitVector` objects from a [`MissRow`](@ref)
 constraint.  The sampled vectors will have length `H`.
@@ -111,7 +111,7 @@ the random sampling from regular languages." Algorithmica 62.1 (2012): 130-145.
 # Examples
 
 ```julia-repl
-julia> sp = SamplerMissRow(MissRow(3), 10);
+julia> sp = SamplerUniformMissRow(MissRow(3), 10);
 
 julia> rand(sp)
 10-element BitVector:
@@ -127,7 +127,7 @@ julia> rand(sp)
 1
 ```
 """
-function SamplerMissRow(constraint::MissRow, H::Int64)
+function SamplerUniformMissRow(constraint::MissRow, H::Int64)
     l = zeros(BigInt, constraint.miss+2, H+1)
     l[1:constraint.miss+1, 1] .= 1
     for i = 2:H+1
@@ -139,10 +139,10 @@ function SamplerMissRow(constraint::MissRow, H::Int64)
             end
         end
     end
-    SamplerMissRow(constraint, H, l)
+    SamplerUniformMissRow(constraint, H, l)
 end
 
-function Random.rand(rng::Random.AbstractRNG, sp::SamplerMissRow)
+function Random.rand(rng::Random.AbstractRNG, sp::SamplerUniformMissRow)
     q = 0
     ret = falses(sp.H)
     for i = 1:sp.H


### PR DESCRIPTION
To support the statistical hypothesis testing work I've been involved in recently, we need support for sampling from weakly hard constraints. Uniform sampling is nicer to think about than a random walk, so we now implement a fast algorithm for this (cited in the docs).