### PR TITLE
Add satisfies function for weakly hard constraints

### DIFF
--- a/docs/src/weaklyhard.md
+++ b/docs/src/weaklyhard.md
@@ -7,7 +7,8 @@ RealTimeScheduling provides basic support for weakly hard constraints.
     still very incomplete.  For now, we mainly support the constraints
     themselves, as well as comparisons between them.
 
-Constraints that are logically equivalent compare as equal:
+Constraints that are logically equivalent compare as equal, even if they are
+represented differently.
 
 ```@jldoctest
 julia> MeetAny(1, 1) == MeetRow(3, 5) == MissRow(0) == HardRealTime()
@@ -20,6 +21,17 @@ julia> MeetRow(4, 5) == MeetRow(2, 5)
 false
 ```
 
+Testing whether a `BitVector` satisfies a [`WeaklyHardConstraint`](@ref) is
+supported.
+
+```@jldoctest
+julia> BitVector([0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1]) ⊢ MeetRow(2, 5)
+true
+
+julia> BitVector([0, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1]) ⊢ MeetRow(2, 5)
+false
+```
+
 
 ```@docs
 WeaklyHardConstraint
@@ -29,6 +41,8 @@ MeetRow
 MissRow
 HardRealTime
 BestEffort
+satisfies
+⊢
 ```
 
 ## Sampling from Weakly Hard Constraints

--- a/docs/src/weaklyhard.md
+++ b/docs/src/weaklyhard.md
@@ -43,6 +43,7 @@ HardRealTime
 BestEffort
 satisfies
 ⊢
+⊬
 ```
 
 ## Sampling from Weakly Hard Constraints

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -33,6 +33,7 @@ export AbstractRealTimeTask,
        SamplerUniformMissRow,
        satisfies,
        ⊢,
+       ⊬,
        # Schedulability tests
        schedulable_fixed_priority
 include("weaklyhard.jl")

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -31,6 +31,8 @@ export AbstractRealTimeTask,
        HardRealTime,
        BestEffort,
        SamplerUniformMissRow,
+       satisfies,
+       ⊢,
        # Schedulability tests
        schedulable_fixed_priority
 include("weaklyhard.jl")

--- a/src/weaklyhard.jl
+++ b/src/weaklyhard.jl
@@ -244,6 +244,11 @@ Check that the `BitVector` `bv` satisfies the weakly hard constraint given by `c
 satisfies(_::BitVector, c::WeaklyHardConstraint{<:Integer}) = throw(MethodError(satisfies, (typeof(c))))
 @doc (@doc satisfies)
 ⊢(bv::BitVector, c::WeaklyHardConstraint) = satisfies(bv, c)
+"""
+    ⊬(bv::BitVector, c::WeaklyHardConstraint)
+
+Check that the `BitVector` `bv` does *not* satisfy the weakly hard constraint given by `c`.
+"""
 ⊬(bv::BitVector, c::WeaklyHardConstraint) = !satisfies(bv, c)
 # First, the trivial methods
 satisfies(bv::BitVector, _::HardRealTime) = all(bv)

--- a/src/weaklyhard.jl
+++ b/src/weaklyhard.jl
@@ -244,6 +244,7 @@ Check that the `BitVector` `bv` satisfies the weakly hard constraint given by `c
 satisfies(_::BitVector, c::WeaklyHardConstraint{<:Integer}) = throw(MethodError(satisfies, (typeof(c))))
 @doc (@doc satisfies)
 ⊢(bv::BitVector, c::WeaklyHardConstraint) = satisfies(bv, c)
+⊬(bv::BitVector, c::WeaklyHardConstraint) = !satisfies(bv, c)
 # First, the trivial methods
 satisfies(bv::BitVector, _::HardRealTime) = all(bv)
 satisfies(_::BitVector, _::BestEffort) = true

--- a/test/weaklyhard.jl
+++ b/test/weaklyhard.jl
@@ -1,23 +1,7 @@
 @testset "Weakly hard constraints" begin
-    # Construction
-    @test_throws DomainError MeetAny(-1, 5)
-    @test_throws DomainError MeetAny(1, -1)
-    @test_throws DomainError MeetAny(-1, -1)
-    @test_throws DomainError MeetAny(6, 5)
     a = MeetAny(1, 5)
-    @test a.meet == 1
-    @test a.window == 5
-    @test_throws DomainError MeetRow(-1, 5)
-    @test_throws DomainError MeetRow(1, -1)
-    @test_throws DomainError MeetRow(-1, -1)
-    @test_throws DomainError MeetRow(6, 5)
-    b = MeetRow(1, 5)
-    @test b.meet == 1
-    @test b.window == 5
-    @test_throws DomainError MissRow(-1)
+    b = MeetRow(2, 5)
     c = MissRow(3)
-    @test c.miss == 3
-    # Equality
     d = MissRow(0)
     e = MeetRow(3, 5)
     f = MeetAny(4, 4)
@@ -25,15 +9,58 @@
     h = MeetRow(0, 5)
     i = MeetAny(0, 3)
     j = BestEffort()
-    C = [a b c d e f g h i j] .== [a;b;c;d;e;f;g;h;i;j]
-    @test C == [1 0 0 0 0 0 0 0 0 0
-                0 1 0 0 0 0 0 0 0 0
-                0 0 1 0 0 0 0 0 0 0
-                0 0 0 1 1 1 1 0 0 0
-                0 0 0 1 1 1 1 0 0 0
-                0 0 0 1 1 1 1 0 0 0
-                0 0 0 1 1 1 1 0 0 0
-                0 0 0 0 0 0 0 1 1 1
-                0 0 0 0 0 0 0 1 1 1
-                0 0 0 0 0 0 0 1 1 1]
+    @testset "Construction invariants" begin
+        @test_throws DomainError MeetAny(-1, 5)
+        @test_throws DomainError MeetAny(1, -1)
+        @test_throws DomainError MeetAny(-1, -1)
+        @test_throws DomainError MeetAny(6, 5)
+
+        @test_throws DomainError MeetRow(-1, 5)
+        @test_throws DomainError MeetRow(1, -1)
+        @test_throws DomainError MeetRow(-1, -1)
+        @test_throws DomainError MeetRow(6, 5)
+
+        @test_throws DomainError MissRow(-1)
+    end
+    @testset "Properties" begin
+        @test a.meet == 1
+        @test a.window == 5
+        @test b.meet == 2
+        @test b.window == 5
+        @test c.miss == 3
+    end
+    @testset "Equality" begin
+        C = [a b c d e f g h i j] .== [a;b;c;d;e;f;g;h;i;j]
+        @test C == [1 0 0 0 0 0 0 0 0 0
+                    0 1 0 0 0 0 0 0 0 0
+                    0 0 1 0 0 0 0 0 0 0
+                    0 0 0 1 1 1 1 0 0 0
+                    0 0 0 1 1 1 1 0 0 0
+                    0 0 0 1 1 1 1 0 0 0
+                    0 0 0 1 1 1 1 0 0 0
+                    0 0 0 0 0 0 0 1 1 1
+                    0 0 0 0 0 0 0 1 1 1
+                    0 0 0 0 0 0 0 1 1 1]
+    end
+    @testset "Satisfaction" begin
+        bv = Matrix{BitVector}(undef, 1, 4)
+        bv[1,1] = BitVector([0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 1])
+        bv[1,2] = BitVector([0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1])
+        bv[1,3] = BitVector([0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1])
+        bv[1,4] = BitVector([0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 1])
+        S = satisfies.(bv, [a;b;c])
+        @test S == [1 1 1 0
+                    1 0 0 0
+                    1 1 0 0]
+        S = bv .⊢ [a;b;c]
+        @test S == [1 1 1 0
+                    1 0 0 0
+                    1 1 0 0]
+    end
+    @testset "Random generation" begin
+        # Test that all samples satisfy the constraint
+        sp = SamplerUniformMissRow(c, 100)
+        seqs = rand(sp, 1000)
+        @test all(seqs .⊢ c)
+    end
 end

--- a/test/weaklyhard.jl
+++ b/test/weaklyhard.jl
@@ -60,6 +60,12 @@
                     1 1 0 0
                     0 0 0 0
                     1 1 1 1]
+        S = bv .⊬ [a;b;c;g;j]
+        @test S == [0 0 0 1
+                    0 1 1 1
+                    0 0 1 1
+                    1 1 1 1
+                    0 0 0 0]
     end
     @testset "Random generation" begin
         # Test that all samples satisfy the constraint

--- a/test/weaklyhard.jl
+++ b/test/weaklyhard.jl
@@ -48,14 +48,18 @@
         bv[1,2] = BitVector([0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1])
         bv[1,3] = BitVector([0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 1, 1])
         bv[1,4] = BitVector([0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 1])
-        S = satisfies.(bv, [a;b;c])
+        S = satisfies.(bv, [a;b;c;g;j])
         @test S == [1 1 1 0
                     1 0 0 0
-                    1 1 0 0]
-        S = bv .⊢ [a;b;c]
+                    1 1 0 0
+                    0 0 0 0
+                    1 1 1 1]
+        S = bv .⊢ [a;b;c;g;j]
         @test S == [1 1 1 0
                     1 0 0 0
-                    1 1 0 0]
+                    1 1 0 0
+                    0 0 0 0
+                    1 1 1 1]
     end
     @testset "Random generation" begin
         # Test that all samples satisfy the constraint


### PR DESCRIPTION
One of the most fundamental things to do with weakly hard constraints is to check if a given pattern of hits and misses satisfies a constraint.  This was a glaring omission in the 0.1.0 release.  This PR adds the function `satisfies` to compute this for all our concrete constraint types.  It also adds a synonymous `⊢` operator.  The function only works for strings of at least the window size, because although Bernat, Burns, and Llamosí define a meaning for short strings, the resulting three-state logic seems more confusing than it's worth in practice.  Though if a compelling use case arises, I'll not be opposed to implementing it!