### PR TITLE
Add randtasksystem function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Clara Hobbs"]
 version = "0.2.0"
 
 [deps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/docs/src/tasksystems.md
+++ b/docs/src/tasksystems.md
@@ -9,6 +9,15 @@ AbstractRealTimeTaskSystem
 TaskSystem
 ```
 
+## Generating Task Systems
+
+Task systems can be generated at random using common algorithms from the
+real-time literature.  This is useful for conducting schedulability studies.
+
+```@docs
+randtasksystem
+```
+
 ## Testing Properties of Task Systems
 
 As with individual tasks, it can be useful to check if *all* tasks in a task

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -22,6 +22,7 @@ export AbstractRealTimeTask,
        TaskSystem,
        rate_monotonic!,
        deadline_monotonic!,
+       randtasksystem,
        # Weakly-hard constraints
        WeaklyHardConstraint,
        MeetAny,


### PR DESCRIPTION
This PR adds a new function for generating random task systems, predictably named `randtasksystem`.  It follows common methodology from the literature, generating random tasks from the given utilization and period distributions until one more would exceed a utilization bound.

Closes #10.