### PR TITLE
Implement compliant vector analysis for GEDF tardiness bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ authors = ["Clara Hobbs"]
 version = "0.2.0"
 
 [deps]
+Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,14 @@ DocMeta.setdocmeta!(RealTimeScheduling, :DocTestSetup, :(using RealTimeSchedulin
 makedocs(
     sitename = "RealTimeScheduling",
     format = Documenter.HTML(),
-    modules = [RealTimeScheduling]
+    modules = [RealTimeScheduling],
+    pages = [
+        "index.md",
+        "tasks.md",
+        "tasksystems.md",
+        "responsetime.md",
+        "weaklyhard.md",
+    ]
 )
 
 # Documenter can also automatically deploy documentation to gh-pages.

--- a/docs/src/responsetime.md
+++ b/docs/src/responsetime.md
@@ -1,0 +1,45 @@
+# Response Time Analysis
+
+RealTimeScheduling supports calculating response time and tardiness bounds for
+task systems under global earliest deadline first (GEDF) scheduling.  Multiple
+algorithms are supported, as shown below.
+
+```@jldoctest responsetime
+julia> T = TaskSystem([PeriodicImplicitTask(3, 2), PeriodicImplicitTask(3, 2), PeriodicImplicitTask(6, 4)]);
+
+julia> tardiness_gedf(T, 2, GEDFDeviAnderson)
+3-element Vector{Float64}:
+ 3.0
+ 3.0
+ 5.0
+
+julia> tardiness_gedf(T, 2, GEDFCompliantVector)
+3-element Vector{Float64}:
+ 3.0
+ 3.0
+ 4.0
+```
+
+Intuitively, increasing the number of processors results in lower response time
+bounds for the same task system.
+
+```@jldoctest responsetime
+julia> tardiness_gedf(T, 3, GEDFDeviAnderson)
+3-element Vector{Float64}:
+ 2.6666666666666665
+ 2.6666666666666665
+ 4.666666666666667
+
+julia> tardiness_gedf(T, 3, GEDFCompliantVector)
+3-element Vector{Float64}:
+ 2.6666666666666665
+ 2.6666666666666665
+ 4.0
+```
+
+```@docs
+tardiness_gedf
+response_time_gedf
+GEDFDeviAnderson
+GEDFCompliantVector
+```

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -38,6 +38,7 @@ export AbstractRealTimeTask,
        schedulable_fixed_priority,
        # Response time calculation
        GEDFDeviAnderson,
+       GEDFCompliantVector,
        response_time_gedf,
        tardiness_gedf
 include("weaklyhard.jl")

--- a/src/responsetime.jl
+++ b/src/responsetime.jl
@@ -38,7 +38,7 @@ end
     tardiness_gedf(T, m, ::GEDFDeviAndersonAlg)
 
 Compute tardiness bounds for each task in the [`TaskSystem`](@ref) `T` under GEDF
-scheduling on `m` processors, according to the `GEDFDeviAnderson` algorithm.
+scheduling on `m` processors, according to the [`GEDFDeviAnderson`](@ref) algorithm.
 """
 function tardiness_gedf(T::TaskSystem{<:PeriodicImplicitTask}, m::Integer, ::GEDFDeviAndersonAlg)
     m > 1 || throw(ArgumentError("m must be at least 2"))
@@ -63,7 +63,7 @@ end
     tardiness_gedf(T, m, ::GEDFCompliantVectorAlg)
 
 Compute tardiness bounds for each task in the [`TaskSystem`](@ref) `T` under GEDF
-scheduling on `m` processors, according to the `GEDFCompliantVector` algorithm.
+scheduling on `m` processors, according to the [`GEDFCompliantVector`](@ref) algorithm.
 """
 function tardiness_gedf(T::TaskSystem{<:AbstractRealTimeTask}, m::Integer, ::GEDFCompliantVectorAlg)
     m > 1 || throw(ArgumentError("m must be at least 2"))

--- a/src/responsetime.jl
+++ b/src/responsetime.jl
@@ -1,6 +1,7 @@
 abstract type GEDFAlgorithm end
 
 struct GEDFDeviAndersonAlg <: GEDFAlgorithm end
+struct GEDFCompliantVectorAlg <: GEDFAlgorithm end
 
 """
     GEDFDeviAnderson
@@ -10,6 +11,15 @@ Indicate that a response time bound should be computed according to Devi and And
 DOI: https://doi.org/10.1007/s11241-007-9042-1
 """
 const GEDFDeviAnderson = GEDFDeviAndersonAlg()
+
+"""
+    GEDFCompliantVector
+
+Indicate that a response time bound should be computed according to Erickson, Devi, and
+Baruah, "Improved Tardiness Bounds for Global EDF."
+DOI: https://doi.org/10.1109/ECRTS.2010.25
+"""
+const GEDFCompliantVector = GEDFCompliantVectorAlg()
 
 """
     response_time_gedf(T, m, alg)

--- a/src/responsetime.jl
+++ b/src/responsetime.jl
@@ -15,9 +15,9 @@ const GEDFDeviAnderson = GEDFDeviAndersonAlg()
 """
     GEDFCompliantVector
 
-Indicate that a response time bound should be computed according to Erickson, Devi, and
-Baruah, "Improved Tardiness Bounds for Global EDF."
-DOI: https://doi.org/10.1109/ECRTS.2010.25
+Indicate that a response time bound should be computed according to Erickson, Guan, and
+Baruah, "Tardiness Bounds for Global EDF with Deadlines Different from Periods."
+DOI: https://doi.org/10.1007/978-3-642-17653-1_22
 """
 const GEDFCompliantVector = GEDFCompliantVectorAlg()
 
@@ -27,7 +27,7 @@ const GEDFCompliantVector = GEDFCompliantVectorAlg()
 Compute response time bounds for each task in the [`TaskSystem`](@ref) `T` under GEDF
 scheduling on `m` processors, according to the specified algorithm.
 """
-function response_time_gedf(T::TaskSystem{<:PeriodicImplicitTask}, m::Integer, alg::GEDFAlgorithm)
+function response_time_gedf(T::TaskSystem{<:AbstractRealTimeTask}, m::Integer, alg::GEDFAlgorithm)
     return tardiness_gedf(T, m, alg) .+ deadline.(T)
 end
 
@@ -54,4 +54,63 @@ function tardiness_gedf(T::TaskSystem{<:PeriodicImplicitTask}, m::Integer, ::GED
         x = (sum(cost, ϵ[1:Λ]) - cost(ϵ[end])) / (m - sum(utilization, μ[1:Λ-1]))
     end
     return x .+ cost.(T)
+end
+
+_S(τ::AbstractRealTimeTask) = cost(τ) * max(0, 1 − deadline(τ) / period(τ))
+_S(T::AbstractRealTimeTaskSystem) = sum(_S, T)
+
+"""
+    tardiness_gedf(T, m, ::GEDFCompliantVectorAlg)
+
+Compute tardiness bounds for each task in the [`TaskSystem`](@ref) `T` under GEDF
+scheduling on `m` processors, according to the `GEDFCompliantVector` algorithm.
+"""
+function tardiness_gedf(T::TaskSystem{<:AbstractRealTimeTask}, m::Integer, ::GEDFCompliantVectorAlg)
+    m > 1 || throw(ArgumentError("m must be at least 2"))
+    utilization(T) <= m || throw(ArgumentError("T must be feasible on m processors"))
+    utilization(T) > 1 || return zeros(length(T))
+
+    # Algorithm 1 from Erickson, Guan, and Baruah
+    m0 = ceil(Int, utilization(T))
+    _z(i, j) = (cost(i) + (cost(j)*utilization(j)) / m + (-cost(i)*utilization(i)) / m - cost(j)) / (utilization(j) - utilization(i))
+    points = Tuple{Float64, AbstractRealTimeTask, AbstractRealTimeTask}[]
+    for i in eachindex(T)
+        for j in 1:i-1
+            if utilization(T[i]) != utilization(T[j])
+                push!(points, (_z(T[i], T[j]), T[i], T[j]))
+            end
+        end
+    end
+
+    z0 = 0
+    pind = 1
+    if pind <= length(points)
+        z1, i, j = points[pind]
+        pid += 1
+    else
+        z1 = Inf
+    end
+
+    _sumterm(τ, z=0) = utilization(τ) * (z - cost(τ) / m) + cost(τ)
+    Θ = sort(T, by=_sumterm, rev=true)[1:m0]
+    zstar = 0
+    while true
+        @info "status" zstar z0 z1
+        zstar = ((_S(T) - sum(τ -> cost(τ) * (1 - utilization(τ) / m), Θ))
+                 / (sum(utilization, Θ) - m))
+        if z0 <= zstar <= z1
+            break
+        elseif i ∈ Θ && j ∉ Θ && utilization(j) > utilization(i)
+            Θ[findfirst(task -> task == i, Θ)] = j
+        end
+        z0 = z1
+        if pind <= length(points)
+            z1, i, j = points[pind]
+            pind += 1
+        else
+            z1 = Inf
+        end
+    end
+
+    return zstar .- cost.(T) ./ m .+ cost.(T)
 end


### PR DESCRIPTION
This commit implements CVA for computing GEDF response time bounds, following the linear program in Jeremy Erickson's dissertation.  It also adds documentation for the response time bound API, which was accidentally missing from #9.

I'm not thrilled about bringing in JuMP as a dependency for one method of one function, but there are other things we can use it for later.  In particular, CVA can be extended to add support for computing the task priorities for GFL scheduling, which would be great to have, especially once #7 is completed.

Closes #8.