### PR TITLE
Add scheduling simulation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -23,4 +23,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
           DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}
+          GKSwstype: "100"
         run: julia --project=docs/ docs/make.jl

--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,15 @@ version = "0.2.0"
 
 [deps]
 Clp = "e2554f3b-3117-50c0-817c-e040a3ddf72d"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
-Distributions = "0.25"
 Clp = "1"
+Distributions = "0.25"
 JuMP = "1"
 julia = "^1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [compat]
 Clp = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 RealTimeScheduling = "f1524149-62f5-490d-8249-9bfac76a7111"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+RealTimeScheduling = "f1524149-62f5-490d-8249-9bfac76a7111"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(
         "index.md",
         "tasks.md",
         "tasksystems.md",
+        "schedules.md",
         "responsetime.md",
         "weaklyhard.md",
     ]

--- a/docs/src/schedules.md
+++ b/docs/src/schedules.md
@@ -1,0 +1,45 @@
+# Scheduling
+
+RealTimeScheduling implements a simple yet flexible scheduling simulator
+supporting preemptive global job-level fixed priority scheduling of
+[`TaskSystem`](@ref) structs.  It also supports generating plots of the
+resulting schedules using the [Plots.jl](https://docs.juliaplots.org/stable/)
+package.
+
+```@example
+using RealTimeScheduling, Plots
+T = TaskSystem([PeriodicImplicitTask(3, 2), PeriodicImplicitTask(3, 2), PeriodicImplicitTask(3, 2)])
+s = schedule_gedf(T, 2, 30.)
+plot(s)
+```
+
+```@docs
+schedule_global
+schedule_gedf
+schedule_gfp
+AbstractSchedule
+AbstractTaskSchedule
+RealTimeTaskSchedule
+RealTimeTaskSchedule(::Type, ::AbstractRealTimeTaskSystem)
+```
+
+## Concrete Jobs
+
+Schedule objects contain a `Vector` of `Vector`s of [`AbstractJob`](@ref)
+objects.  These contain all the parameters of a concrete real-time job:
+[`release`](@ref), [`deadline`](@ref), [`cost`](@ref), and [`priority`](@ref),
+as well as a `Vector` of [`ExecInterval`](@ref) objects.
+
+```@docs
+AbstractJob
+AbstractJobOfTask
+Job
+JobOfTask
+task(::AbstractJobOfTask)
+release(::AbstractJob)
+deadline(::AbstractJob)
+cost(::AbstractJob)
+priority(::AbstractJob)
+exec
+ExecInterval
+```

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -22,9 +22,9 @@ Of course, methods are provided to get a task's period, relative deadline, and
 execution cost.
 
 ```@docs
-period
-deadline
-cost
+period(::AbstractRealTimeTask)
+deadline(::AbstractRealTimeTask)
+cost(::AbstractRealTimeTask)
 ```
 
 Utilization and density can be computed easily as well.

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -36,6 +36,8 @@ export AbstractRealTimeTask,
        AbstractSchedule,
        AbstractTaskSchedule,
        RealTimeTaskSchedule,
+       schedule_global,
+       schedule_gfp,
        schedule_gedf,
        # Weakly-hard constraints
        WeaklyHardConstraint,

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -23,6 +23,20 @@ export AbstractRealTimeTask,
        rate_monotonic!,
        deadline_monotonic!,
        randtasksystem,
+       # Schedules
+       ExecInterval,
+       AbstractJob,
+       AbstractJobOfTask,
+       Job,
+       JobOfTask,
+       task,
+       release,
+       priority,
+       exec,
+       AbstractSchedule,
+       AbstractTaskSchedule,
+       RealTimeTaskSchedule,
+       schedule_gedf,
        # Weakly-hard constraints
        WeaklyHardConstraint,
        MeetAny,
@@ -45,6 +59,7 @@ export AbstractRealTimeTask,
 include("weaklyhard.jl")
 include("tasks.jl")
 include("tasksystems.jl")
+include("schedules.jl")
 include("schedulability.jl")
 include("responsetime.jl")
 

--- a/src/schedules.jl
+++ b/src/schedules.jl
@@ -73,7 +73,9 @@ Return the priority of job `j`.
 priority(::AbstractJob) = error("Implement priority")
 
 """
-Real-time job type.
+    Job{S}(release::S, deadline::S, cost::S, priority::S, exec::Vector{ExecInterval{S}}
+
+A real-time job with the given parameters, executing over the intervals in `exec`.
 """
 mutable struct Job{S} <: AbstractJob
     release::S
@@ -104,7 +106,10 @@ Return the task associated with job `j`.
 task(::AbstractJobOfTask) = error("Implement task")
 
 """
-Job of a real-time task.
+    JobOfTask{S, T}(task::T, release::S, deadline::S, cost::S, priority::S, exec::Vector{ExecInterval{S}}
+
+A real-time job of the given `task` with the given parameters, executing over the intervals
+in `exec`.
 """
 mutable struct JobOfTask{S <: Real, T} <: AbstractJobOfTask{T}
     task::T
@@ -138,6 +143,8 @@ Abstract supertype for all real-time schedules of task systems.
 abstract type AbstractTaskSchedule{T <: AbstractJobOfTask} <: AbstractSchedule{T} end
 
 """
+    RealTimeTaskSchedule{T}(tasks::AbstractRealTimeTaskSystem, jobs::Vector{Vector{T}})
+
 Schedule of a real-time task system.
 """
 mutable struct RealTimeTaskSchedule{T} <: AbstractTaskSchedule{T}

--- a/src/schedules.jl
+++ b/src/schedules.jl
@@ -188,13 +188,17 @@ function schedule_gedf(release!, T::AbstractRealTimeTaskSystem, m::Int, endtime:
             push!(jobs, j)
             enqueue!(readyq, j, priority(j))
         end
-        # Pick jobs to run and find next interesting time instant
+        # Clear out any completed jobs
         for (proc, j) in enumerate(proc_jobs)
             # Clear out any completed jobs
             if j !== nothing && sum(width.(exec(j))) >= cost(j)
                 proc_jobs[proc] = nothing
                 j = nothing
             end
+        end
+        # Pick jobs to run and find next interesting time instant
+        sortby(key) = key[2] === nothing ? typemax(timetype) : priority(key[2])
+        for (proc, j) in sort(collect(enumerate(proc_jobs)), by=sortby, rev=true)
             # Pick new jobs for idle processors
             if !isempty(readyq) && j === nothing
                 proc_jobs[proc] = dequeue!(readyq)

--- a/src/schedules.jl
+++ b/src/schedules.jl
@@ -281,8 +281,10 @@ end
     layout --> (length(sched.tasks), 1)
     xlims --> (0, endtime)
     ylims --> (0, 2)
-    yticks --> false
+    ytickfontcolor --> "#00000000" # Workaround for guides getting cut off
+    yticks --> [0]
     xgrid --> false
+    ygrid --> false
     # First draw the execution intervals
     for (i, τ) in enumerate(sched.jobs)
         for j in τ
@@ -346,6 +348,7 @@ end
                 xguide --> "Time"
             end
             yguide --> "Task $i"
+            yguidefonthalign --> :left
             label --> ""
             [0], [0]
         end

--- a/src/schedules.jl
+++ b/src/schedules.jl
@@ -89,6 +89,11 @@ release(j::Job) = j.release
 deadline(j::Job) = j.deadline
 cost(j::Job) = j.cost
 priority(j::Job) = j.priority
+"""
+    exec(j::Job)
+
+Return the execution intervals of job `j`.
+"""
 exec(j::Job) = j.exec
 
 """
@@ -125,6 +130,11 @@ release(j::JobOfTask) = j.release
 deadline(j::JobOfTask) = j.deadline
 cost(j::JobOfTask) = j.cost
 priority(j::JobOfTask) = j.priority
+"""
+    exec(j::JobOfTask)
+
+Return the execution intervals of job `j`.
+"""
 exec(j::JobOfTask) = j.exec
 
 

--- a/src/schedules.jl
+++ b/src/schedules.jl
@@ -244,7 +244,7 @@ schedule_gedf(T::AbstractRealTimeTaskSystem, m::Int, time::Real) = schedule_gedf
             for ei in exec(j)
                 l, r = endpoints(ei)
                 @series begin
-                    subplot --> i
+                    subplot := i
                     label --> ""
                     seriestype := :shape
                     fillcolor --> processor(ei)
@@ -262,31 +262,31 @@ schedule_gedf(T::AbstractRealTimeTaskSystem, m::Int, time::Real) = schedule_gedf
             comp = total_exec == cost(j) ? maximum(rightendpoint.(exec(j))) : -1
             # Release
             @series begin
-                subplot --> i
+                subplot := i
                 label --> ""
                 seriestype := :path
                 linecolor --> :black
-                arrow --> true
+                arrow := true
                 [rel, rel], [0, 2]
             end
             # Deadline
             @series begin
-                subplot --> i
+                subplot := i
                 label --> ""
                 seriestype := :path
                 linecolor --> :black
-                arrow --> true
+                arrow := true
                 [dead, dead], [2, 0]
             end
             # Completion
             @series begin
-                subplot --> i
+                subplot := i
                 label --> ""
                 seriestype := :path
                 linecolor --> :black
-                markershape --> [:none, :hline]
+                markershape := [:none, :hline]
                 markeralpha --> [0, 1]
-                markerstrokewidth --> 2
+                markerstrokewidth --> 2*get(plotattributes, :linewidth, 1)
                 markerstrokecolor --> :black
                 markercolor --> :black
                 [comp, comp], [0, 2]
@@ -296,7 +296,7 @@ schedule_gedf(T::AbstractRealTimeTaskSystem, m::Int, time::Real) = schedule_gedf
     # Per-subplot settings
     for (i, τ) in enumerate(sched.tasks)
         @series begin
-            subplot --> i
+            subplot := i
             if i == length(sched.tasks)
                 xguide --> "Time"
             end

--- a/src/schedules.jl
+++ b/src/schedules.jl
@@ -1,0 +1,159 @@
+using DataStructures
+using IntervalSets
+
+
+"""
+    ExecInterval{S}(start::S, stop::S, proc::Int)
+
+Interval type for job execution, with a specified processor index.  Always assumed to be
+half open, i.e., `[start, stop)`.
+"""
+struct ExecInterval{S} <: AbstractInterval{S}
+    start::S
+    stop::S
+    proc::Int
+    function ExecInterval{S}(start::S, stop::S, proc::Int) where {S<:Real}
+        @boundscheck start < stop || throw(DomainError("start must be less than stop"))
+        @boundscheck proc > 0 || throw(DomainError("proc must be positive"))
+        new(start, stop, proc)
+    end
+end
+
+IntervalSets.endpoints(i::ExecInterval) = (i.start, i.stop)
+IntervalSets.closedendpoints(::ExecInterval) = (true, false)
+processor(i::ExecInterval) = i.proc
+
+Base.in(x::Real, i::ExecInterval) = leftendpoint(i) <= x < rightendpoint(i)
+
+function Base.union(i::ExecInterval, j::ExecInterval)
+    processor(i) == processor(j) ||
+        throw(ArgumentError("Cannot construct union of execution on different processors"))
+    any(∈(i), endpoints(j)) || any(∈(j), endpoints(i)) ||
+        throw(ArgumentError("Cannot construct union of disjoint sets"))
+    l = min(leftendpoint(i), leftendpoint(j))
+    r = max(rightendpoint(i), rightendpoint(j))
+    ExecInterval(l, r, processor(i))
+end
+
+
+"""
+    AbstractJob
+
+Abstract supertype for all real-time jobs.
+"""
+abstract type AbstractJob end
+
+"""
+    release(j::AbstractJob)
+
+Return the release time of job `j`.
+"""
+release(::AbstractJob) = error("Implement release")
+
+"""
+    deadline(j::AbstractJob)
+
+Return the absolute deadline of job `j`.
+"""
+deadline(::AbstractJob) = error("Implement deadline")
+
+"""
+    cost(j::AbstractJob)
+
+Return the execution cost of job `j`.
+"""
+cost(::AbstractJob) = error("Implement cost")
+
+"""
+    priority(j::AbstractJob)
+
+Return the priority of job `j`.
+"""
+priority(::AbstractJob) = error("Implement priority")
+
+"""
+Real-time job type.
+"""
+mutable struct Job{S} <: AbstractJob
+    release::S
+    deadline::S
+    cost::S
+    priority::S
+    exec::Vector{ExecInterval{S}}
+end
+
+release(j::Job) = j.release
+deadline(j::Job) = j.deadline
+cost(j::Job) = j.cost
+priority(j::Job) = j.priority
+exec(j::Job) = j.exec
+
+"""
+    AbstractJobOfTask{T}
+
+Abstract supertype for all real-time jobs of tasks.
+"""
+abstract type AbstractJobOfTask{T <: AbstractRealTimeTask} <: AbstractJob end
+
+"""
+    task(j::AbstractJobOfTask)
+
+Return the task associated with job `j`.
+"""
+task(::AbstractJobOfTask) = error("Implement task")
+
+"""
+Job of a real-time task.
+"""
+mutable struct JobOfTask{S <: Real, T} <: AbstractJobOfTask{T}
+    task::T
+    release::S
+    deadline::S
+    cost::S
+    priority::S
+    exec::Vector{ExecInterval{S}}
+end
+
+task(j::JobOfTask) = j.task
+release(j::JobOfTask) = j.release
+deadline(j::JobOfTask) = j.deadline
+cost(j::JobOfTask) = j.cost
+priority(j::JobOfTask) = j.priority
+exec(j::JobOfTask) = j.exec
+
+
+"""
+    AbstractSchedule{T}
+
+Abstract supertype for all real-time schedules.
+"""
+abstract type AbstractSchedule{T <: AbstractJob} end
+
+"""
+    AbstractTaskSchedule{T}
+
+Abstract supertype for all real-time schedules of task systems.
+"""
+abstract type AbstractTaskSchedule{T <: AbstractJobOfTask} <: AbstractSchedule{T} end
+
+"""
+Schedule of a real-time task system.
+"""
+mutable struct RealTimeTaskSchedule{T} <: AbstractTaskSchedule{T}
+    tasks::AbstractRealTimeTaskSystem
+    jobs::Vector{Vector{T}}
+end
+
+function schedule_gedf(release!, T::AbstractRealTimeTaskSystem, m::Int, time::Real)
+    # Create the schedule
+    sched = RealTimeTaskSchedule(T, Vector{Vector{JobOfTask{typeof(time), eltype(T)}}}(undef, length(T)))
+    # Initialize the job vectors as empty
+    for v in eachindex(sched.jobs)
+        sched.jobs[v] = JobOfTask{typeof(time), eltype(T)}[]
+    end
+    # Scheduler's priority queue
+    pq = PriorityQueue{eltype(T), typeof(time)}()
+    sched
+end
+
+schedule_gedf(T::AbstractRealTimeTaskSystem, m::Int, time::Real) = schedule_gedf(identity, T, m, time)

--- a/src/tasks.jl
+++ b/src/tasks.jl
@@ -8,6 +8,27 @@ Base.iterate(τ::AbstractRealTimeTask) = (τ, nothing)
 Base.iterate(_::AbstractRealTimeTask, _) = nothing
 
 """
+    period(τ::AbstractRealTimeTask)
+
+Return the period of the real-time task `τ`.
+"""
+period(::AbstractRealTimeTask) = error("Implement period")
+
+"""
+    deadline(τ::AbstractRealTimeTask)
+
+Return the deadline of the real-time task `τ`.
+"""
+deadline(::AbstractRealTimeTask) = error("Implement deadline")
+
+"""
+    cost(τ::AbstractRealTimeTask)
+
+Return the cost, or worst-case execution time, of the real-time task `τ`.
+"""
+cost(::AbstractRealTimeTask) = error("Implement cost")
+
+"""
     PeriodicTask{S}(period::S, deadline::S, cost::S)
 
 Concrete type for periodic real-time tasks.
@@ -27,23 +48,8 @@ struct PeriodicTask{S} <: AbstractRealTimeTask{S}
     C::S
 end
 
-"""
-    period(τ)
-
-Return the period of the real-time task `τ`.
-"""
 period(τ::PeriodicTask) = τ.T
-"""
-    deadline(τ)
-
-Return the deadline of the real-time task `τ`.
-"""
 deadline(τ::PeriodicTask) = τ.D
-"""
-    cost(τ)
-
-Return the cost, or worst-case execution time, of the real-time task `τ`.
-"""
 cost(τ::PeriodicTask) = τ.C
 
 


### PR DESCRIPTION
This PR implements a general-purpose global preemptive JLFP scheduling simulator called `schedule_global`, as well as two simple extensions of it: `schedule_gfp` for fixed-priority scheduling (prioritized by task index) and `schedule_gedf` for global EDF scheduling.  Also included is a recipe for plotting schedules with Plots.jl.

Closes #7 