### PR TITLE
Implement job class level scheduling

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,10 @@ makedocs(
         "schedules.md",
         "responsetime.md",
         "weaklyhard.md",
+        "Papers" => [
+            "papers/index.md",
+            "papers/job_class_level_scheduling.md",
+        ]
     ]
 )
 

--- a/docs/src/papers/index.md
+++ b/docs/src/papers/index.md
@@ -12,5 +12,6 @@ your code to this module!
 ## Submodules
 
 ```@docs
+RealTimeScheduling.Papers
 RealTimeScheduling.Papers.JobClassLevelScheduling
 ```

--- a/docs/src/papers/index.md
+++ b/docs/src/papers/index.md
@@ -1,0 +1,16 @@
+# Papers
+
+The module `RealTimeScheduling.Papers` provides implementations of proposed
+algorithms (schedulers, schedulabity tests, etc.) from published papers.  These
+are typically of less broad applicability than the things implemented directly
+in the `RealTimeScheduling` package, but still of interest to the broader
+real-time community.
+
+If you use RealTimeScheduling.jl in your research, please consider contributing
+your code to this module!
+
+## Submodules
+
+```@docs
+RealTimeScheduling.Papers.JobClassLevelScheduling
+```

--- a/docs/src/papers/job_class_level_scheduling.md
+++ b/docs/src/papers/job_class_level_scheduling.md
@@ -1,0 +1,16 @@
+# Job-Class-Level Scheduling
+
+The module `RealTimeScheduling.Papers.JobClassLevelScheduling` implements the 
+scheduler and schedulability test from the paper "Toward Practical Weakly Hard
+Real-Time Systems: A Job-Class-Level Scheduling Approach" by Choi, Kim, and Zhu.
+DOI: [10.1109/JIOT.2021.3058215](https://doi.org/10.1109/JIOT.2021.3058215).
+The scheduler from this paper divides jobs of each task into job-classes on the
+basis of the length of the most recent sequence of consecutive deadline hits,
+and assigns each job-class of each task a fixed priority.  This enables the
+scheduling of weakly hard task systems that are infeasible with any task-level
+fixed priority scheduler.
+
+```@docs
+RealTimeScheduling.Papers.JobClassLevelScheduling.schedule_jcl
+RealTimeScheduling.Papers.JobClassLevelScheduling.miss_threshold
+```

--- a/docs/src/papers/job_class_level_scheduling.md
+++ b/docs/src/papers/job_class_level_scheduling.md
@@ -13,4 +13,8 @@ fixed priority scheduler.
 ```@docs
 RealTimeScheduling.Papers.JobClassLevelScheduling.schedule_jcl
 RealTimeScheduling.Papers.JobClassLevelScheduling.miss_threshold
+RealTimeScheduling.Papers.JobClassLevelScheduling.low_index_first
+RealTimeScheduling.Papers.JobClassLevelScheduling.low_index_first_hold
+RealTimeScheduling.Papers.JobClassLevelScheduling.wcrt_jcl
+RealTimeScheduling.Papers.JobClassLevelScheduling.schedulable_jcl
 ```

--- a/src/RealTimeScheduling.jl
+++ b/src/RealTimeScheduling.jl
@@ -70,5 +70,6 @@ include("tasksystems.jl")
 include("schedules.jl")
 include("schedulability.jl")
 include("responsetime.jl")
+include("papers/Papers.jl")
 
 end

--- a/src/papers/Papers.jl
+++ b/src/papers/Papers.jl
@@ -1,0 +1,14 @@
+"""
+Implementations of proposed algorithms (schedulers, schedulabity tests, etc.) from
+published papers.  These are typically of less broad applicability than the things
+implemented directly in the RealTimeScheduling package, but still of interest to the
+broader real-time community.
+
+If you use RealTimeScheduling.jl in your research, please consider contributing your code
+to this module!
+"""
+module Papers
+
+include("job_class_level_scheduling.jl")
+
+end

--- a/src/papers/job_class_level_scheduling.jl
+++ b/src/papers/job_class_level_scheduling.jl
@@ -11,6 +11,7 @@ export schedule_jcl,
        miss_threshold,
        low_index_first,
        low_index_first_hold,
+       wcrt_jcl,
        schedulable_jcl
 
 
@@ -22,7 +23,6 @@ specified `time`.  Job-class priorities are given by `prio`.
 
 See also [`schedule_global`](@ref) for more general global scheduling.
 """
-
 function schedule_jcl(T::AbstractRealTimeTaskSystem, time::Real, prio)
     schedule_global(T, 1, time, kill=true, pass_schedule=true) do j, sched
         task_index = Int(priority(j))

--- a/src/papers/job_class_level_scheduling.jl
+++ b/src/papers/job_class_level_scheduling.jl
@@ -1,0 +1,44 @@
+"""
+An implementation of the scheduler and schedulability test from the paper "Toward Practical
+Weakly Hard Real-Time Systems: A Job-Class-Level Scheduling Approach" by Choi, Kim, and Zhu.
+DOI: [10.1109/JIOT.2021.3058215](https://doi.org/10.1109/JIOT.2021.3058215)
+"""
+module JobClassLevelScheduling
+
+using ...RealTimeScheduling
+
+export schedule_jcl,
+       miss_threshold
+
+
+"""
+    schedule_jcl(T, time, prio)
+
+Simulate a job-class-level (JCL) schedule of task system `T` on 1 processor for the
+specified `time`.  Job-class priorities are given by `prio`.
+
+See also [`schedule_global`](@ref) for more general global scheduling.
+"""
+function schedule_jcl(T::AbstractRealTimeTaskSystem, time::Real, prio)
+    schedule_global(T, 1, time, kill=true, pass_schedule=true) do j, sched
+        task_index = Int(j.priority)
+        q = 0 # TODO compute job-class of job j
+        j.priority = prio[task_index][q]
+    end
+end
+
+"""
+    miss_threshold(c::MeetAny)
+
+Compute the miss threshold ``w_i`` for the given [`MeetAny`](@ref) constraint.
+"""
+miss_threshold(c::MeetAny) = max(floor(c.window / c.meet) - 1, 1)
+
+"""
+    miss_threshold(τ::PeriodicWeaklyHardTask{<:Real, MeetAny})
+
+Compute the miss threshold ``w_i`` for the given weakly hard task.
+"""
+miss_threshold(τ::PeriodicWeaklyHardTask{<:Real, MeetAny}) = miss_threshold(constraint(τ))
+
+end

--- a/test/papers/Papers.jl
+++ b/test/papers/Papers.jl
@@ -1,0 +1,3 @@
+@testset "Papers" begin
+    include("job_class_level_scheduling.jl")
+end

--- a/test/papers/job_class_level_scheduling.jl
+++ b/test/papers/job_class_level_scheduling.jl
@@ -1,0 +1,14 @@
+@testset "Job-Class-Level Scheduling" begin
+    using RealTimeScheduling.Papers.JobClassLevelScheduling
+
+    # Example from 10.1109/JIOT.2021.3058215
+    wh_ex = TaskSystem([PeriodicWeaklyHardTask(11, 11, 6, MissAny(2, 4)),
+                        PeriodicWeaklyHardTask(7, 7, 4, MissAny(4, 7))])
+    lifw = low_index_first(wh_ex)
+    @test lifw == [[2, 4, 6], [1, 3, 5, 7]]
+    @test schedulable_jcl(wh_ex, lifw)
+    @test low_index_first_hold(wh_ex) == lifw
+    s = schedule_jcl(wh_ex, 100, lifw)
+    @test exectime.(s.jobs[1]) == [6, 6, 4, 6, 5, 6, 6, 6, 6, 0]
+    @test exectime.(s.jobs[2]) == [4, 4, 1, 4, 4, 3, 4, 4, 2, 4, 4, 4, 1, 4, 2]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,6 @@ using Test
     include("schedules.jl")
 
     include("weaklyhard.jl")
+
+    include("papers/Papers.jl")
 end

--- a/test/schedules.jl
+++ b/test/schedules.jl
@@ -10,4 +10,15 @@
     @test completiontime.(s.jobs[2][1:2]) == [4, 7]
     @test_throws ArgumentError completiontime(s.jobs[2][3])
     @test completiontime.(s.jobs[3]) == [2, 6, 9]
+
+    # Example from 10.1109/JIOT.2021.3058215
+    wh_ex = TaskSystem([PeriodicWeaklyHardTask(11, 11, 6, MissAny(2, 4)),
+                        PeriodicWeaklyHardTask(7, 7, 4, MissAny(4, 7))])
+    s = schedule_gfp(wh_ex, 1, 77, kill=true)
+    @test all(exectime.(s.jobs[1]) .== 6)
+    @test exectime.(s.jobs[2]) == [1, 4, 4, 1, 4, 3, 2, 4, 2, 3, 4]
+    rate_monotonic!(wh_ex)
+    s = schedule_gfp(wh_ex, 1, 77, kill=true)
+    @test all(exectime.(s.jobs[1]) .== 4)
+    @test exectime.(s.jobs[2]) == [3, 6, 4, 5, 5, 4, 6]
 end


### PR DESCRIPTION
This PR adds support for Job-Class-Level scheduling, from the paper "Toward Practical Weakly Hard Real-Time Systems: A Job-Class-Level Scheduling Approach" by Choi, Kim, and Zhu.  DOI: [10.1109/JIOT.2021.3058215](https://doi.org/10.1109/JIOT.2021.3058215).

This new code, being fairly special-purpose, is added under a new submodule called `RealTimeScheduling.Papers`.  Its intended purpose is to house code implementing special-purpose algorithms (schedulers, their analysis, etc.) from papers, while not polluting the main package's namespace with myriad acronyms.  In particular, anyone using the `RealTimeScheduling` package in their research is invited to submit high-quality submodules to this `Papers` submodule, to enable greater sharing of research code and direct comparison of similar algorithms.